### PR TITLE
fix: use importlib.metadata for version lookup instead of reading pyp…

### DIFF
--- a/src/alphavantage_mcp_server/__main__.py
+++ b/src/alphavantage_mcp_server/__main__.py
@@ -1,0 +1,5 @@
+"""Entry point for running alphavantage-mcp-server as a module."""
+from . import main
+
+if __name__ == "__main__":
+    main()

--- a/src/alphavantage_mcp_server/server.py
+++ b/src/alphavantage_mcp_server/server.py
@@ -1,10 +1,10 @@
 import asyncio
 import json
 import logging
+from importlib.metadata import version, PackageNotFoundError
 
 import mcp.server.stdio
 import mcp.types as types
-import toml
 import uvicorn
 from mcp.server import NotificationOptions, Server
 from mcp.server.models import InitializationOptions
@@ -2151,9 +2151,12 @@ async def handle_call_tool(
 
 
 def get_version():
-    with open("pyproject.toml", "r") as f:
-        pyproject = toml.load(f)
-        return pyproject["project"]["version"]
+    """Get the package version from installed metadata."""
+    try:
+        return version("alphavantage-mcp")
+    except PackageNotFoundError:
+        # Fallback version if package is not installed (e.g., during development)
+        return "0.0.0-dev"
 
 
 async def run_stdio_server():


### PR DESCRIPTION
…roject.toml

The get_version() function was attempting to read pyproject.toml using a relative path, which fails when the MCP server is run from outside the project directory (e.g., via uvx or installed package).

Changes:
- Replace file-based version reading with importlib.metadata.version()
- Add fallback to "0.0.0-dev" for development scenarios
- Remove unused toml import

This fixes FileNotFoundError in MCP server logs when the server starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)