### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 A MCP server for the stock market data API, Alphavantage API.
 
+<a href="https://glama.ai/mcp/servers/@calvernaz/alphavantage">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@calvernaz/alphavantage/badge" alt="Alpha Vantage Server MCP server" />
+</a>
+
 **MCP Server URL**: https://mcp.alphavantage.co
 
 **PyPi**: https://pypi.org/project/alphavantage-mcp/


### PR DESCRIPTION
This PR adds a badge for the [Alpha Vantage MCP Server](https://glama.ai/mcp/servers/@calvernaz/alphavantage) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@calvernaz/alphavantage">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@calvernaz/alphavantage/badge" alt="Alpha Vantage Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.