### PR TITLE
Change listing_status api datatype from JSON to CSV

### DIFF
--- a/src/alphavantage_mcp_server/api.py
+++ b/src/alphavantage_mcp_server/api.py
@@ -653,7 +653,7 @@ async def fetch_listing_status(
         "state": state,
         "apikey": API_KEY,
     }
-    return await _make_api_request(https_params, "json")
+    return await _make_api_request(https_params, "csv")
 
 
 @instrument_tool("earnings_calendar")


### PR DESCRIPTION
This call was generating an error when used because it returns a CSV while the API data type was set to JSON